### PR TITLE
Remove implicitfor annotation

### DIFF
--- a/src/universe/GUTAnnotatedTypeFactory.java
+++ b/src/universe/GUTAnnotatedTypeFactory.java
@@ -3,9 +3,9 @@ package universe;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodTree;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
-import org.checkerframework.framework.type.treeannotator.ImplicitsTreeAnnotator;
+import org.checkerframework.framework.type.treeannotator.LiteralTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.PropagationTreeAnnotator;
-import org.checkerframework.framework.type.typeannotator.ImplicitsTypeAnnotator;
+import org.checkerframework.framework.type.typeannotator.DefaultForTypeAnnotator;
 import org.checkerframework.javacutil.Pair;
 import universe.qual.Any;
 import universe.qual.Bottom;
@@ -89,7 +89,7 @@ public class GUTAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     protected TreeAnnotator createTreeAnnotator() {
         return new ListTreeAnnotator(
                 new GUTPropagationTreeAnnotator(this),
-                new ImplicitsTreeAnnotator(this),
+                new LiteralTreeAnnotator(this),
                 new GUTTreeAnnotator()
                 );
     }
@@ -162,7 +162,7 @@ public class GUTAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
     private class GUTPropagationTreeAnnotator extends PropagationTreeAnnotator {
         /**
-         * Creates a {@link ImplicitsTypeAnnotator}
+         * Creates a {@link DefaultForTypeAnnotator}
          * from the given checker, using that checker's type hierarchy.
          *
          * @param atypeFactory
@@ -261,7 +261,7 @@ public class GUTAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             return super.visitTypeCast(node, type);
         }
 
-        /**Because TreeAnnotator runs before ImplicitsTypeAnnotator, implicitly immutable types are not guaranteed
+        /**Because TreeAnnotator runs before DefaultForTypeAnnotator, implicitly immutable types are not guaranteed
          to always have immutable annotation. If this happens, we manually add immutable to type. We use
          addMissingAnnotations because we want to respect existing annotation on type*/
         private void applyImmutableIfImplicitlyBottom(AnnotatedTypeMirror type) {

--- a/src/universe/GUTInferenceAnnotatedTypeFactory.java
+++ b/src/universe/GUTInferenceAnnotatedTypeFactory.java
@@ -18,7 +18,7 @@ import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedDeclaredType;
-import org.checkerframework.framework.type.treeannotator.ImplicitsTreeAnnotator;
+import org.checkerframework.framework.type.treeannotator.LiteralTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.ListTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.PropagationTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.TreeAnnotator;
@@ -49,7 +49,7 @@ public class GUTInferenceAnnotatedTypeFactory
 
     @Override
     public TreeAnnotator createTreeAnnotator() {
-        return new ListTreeAnnotator(new ImplicitsTreeAnnotator(this),
+        return new ListTreeAnnotator(new LiteralTreeAnnotator(this),
                 new GUTIInferencePropagationTreeAnnotater(this),
                 new InferenceTreeAnnotator(this, realChecker, realTypeFactory, variableAnnotator, slotManager));
     }
@@ -168,7 +168,7 @@ public class GUTInferenceAnnotatedTypeFactory
             return super.visitTypeCast(node, type);
         }
 
-        /**Because TreeAnnotator runs before ImplicitsTypeAnnotator, implicitly immutable types are not guaranteed
+        /**Because TreeAnnotator runs before DefaultForTypeAnnotator, implicitly immutable types are not guaranteed
          to always have immutable annotation. If this happens, we manually add immutable to type. */
         private void applyBottomIfImplicitlyBottom(AnnotatedTypeMirror type) {
             if (GUTTypeUtil.isImplicitlyBottomType(type)) {

--- a/src/universe/GUTTypeUtil.java
+++ b/src/universe/GUTTypeUtil.java
@@ -7,7 +7,7 @@ import checkers.inference.model.ConstraintManager;
 import checkers.inference.model.Slot;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.util.TreePath;
-import org.checkerframework.framework.qual.ImplicitFor;
+import org.checkerframework.framework.qual.DefaultFor;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.javacutil.TreeUtils;
 import org.checkerframework.javacutil.TypesUtils;
@@ -27,24 +27,24 @@ import static universe.GUTChecker.SELF;
 
 public class GUTTypeUtil {
 
-    private static boolean isInTypesOfImplicitForOfBottom(AnnotatedTypeMirror atm) {
-        ImplicitFor implicitFor = Bottom.class.getAnnotation(ImplicitFor.class);
-        assert implicitFor != null;
-        assert implicitFor.types() != null;
-        for (org.checkerframework.framework.qual.TypeKind typeKind : implicitFor.types()) {
+    private static boolean isInTypesOfDefaultForOfBottom(AnnotatedTypeMirror atm) {
+        DefaultFor defaultFor = Bottom.class.getAnnotation(DefaultFor.class);
+        assert defaultFor != null;
+        assert defaultFor.typeKinds() != null;
+        for (org.checkerframework.framework.qual.TypeKind typeKind : defaultFor.typeKinds()) {
             if (TypeKind.valueOf(typeKind.name()) == atm.getKind()) return true;
         }
         return false;
     }
 
-    private static boolean isInTypeNamesOfImplicitForOfBottom(AnnotatedTypeMirror atm) {
+    private static boolean isInTypeNamesOfDefaultForOfBottom(AnnotatedTypeMirror atm) {
         if (atm.getKind() != TypeKind.DECLARED) {
             return false;
         }
-        ImplicitFor implicitFor = Bottom.class.getAnnotation(ImplicitFor.class);
-        assert implicitFor != null;
-        assert implicitFor.typeNames() != null;
-        Class<?>[] typeNames = implicitFor.typeNames();
+        DefaultFor defaultFor = Bottom.class.getAnnotation(DefaultFor.class);
+        assert defaultFor != null;
+        assert defaultFor.types() != null;
+        Class<?>[] typeNames = defaultFor.types();
         String fqn = TypesUtils.getQualifiedName((DeclaredType) atm.getUnderlyingType()).toString();
         for (int i = 0; i < typeNames.length; i++) {
             if (typeNames[i].getCanonicalName().toString().contentEquals(fqn)) return true;
@@ -53,7 +53,7 @@ public class GUTTypeUtil {
     }
 
     public static boolean isImplicitlyBottomType(AnnotatedTypeMirror atm) {
-        return isInTypesOfImplicitForOfBottom(atm) || isInTypeNamesOfImplicitForOfBottom(atm);
+        return isInTypesOfDefaultForOfBottom(atm) || isInTypeNamesOfDefaultForOfBottom(atm);
     }
 
     public static void applyConstant(AnnotatedTypeMirror type, AnnotationMirror am) {

--- a/src/universe/GUTValidator.java
+++ b/src/universe/GUTValidator.java
@@ -43,7 +43,6 @@ public class GUTValidator extends InferenceValidator {
     public Void visitDeclared(AnnotatedTypeMirror.AnnotatedDeclaredType type, Tree p) {
         checkImplicitlyBottomTypeError(type, p);
         checkStaticRepError(type, p);
-        checkConflictingPrimaryAnnos(type, p);
         // @Peer is allowed in static context
 
         // This will be handled at higher level

--- a/src/universe/qual/Bottom.java
+++ b/src/universe/qual/Bottom.java
@@ -1,7 +1,7 @@
 package universe.qual;
 
 import org.checkerframework.framework.qual.DefaultFor;
-import org.checkerframework.framework.qual.ImplicitFor;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.LiteralKind;
 import org.checkerframework.framework.qual.SubtypeOf;
 import org.checkerframework.framework.qual.TargetLocations;
@@ -26,11 +26,13 @@ import java.math.BigInteger;
 @Target({ElementType.TYPE_PARAMETER, ElementType.TYPE_USE})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND})
 @SubtypeOf({ Self.class, Rep.class })
-@DefaultFor({ TypeUseLocation.LOWER_BOUND })
-@ImplicitFor(literals = { LiteralKind.ALL},
-        types = { TypeKind.INT, TypeKind.BYTE, TypeKind.SHORT, TypeKind.BOOLEAN,
-                TypeKind.LONG, TypeKind.CHAR, TypeKind.FLOAT, TypeKind.DOUBLE },
-        typeNames={String.class, Double.class, Boolean.class, Byte.class,
-                Character.class, Float.class, Integer.class, Long.class, Short.class}
+@DefaultFor(value = { TypeUseLocation.LOWER_BOUND },
+        typeKinds = { TypeKind.INT, TypeKind.BYTE, TypeKind.SHORT,
+                TypeKind.BOOLEAN, TypeKind.LONG, TypeKind.CHAR, TypeKind.FLOAT,
+                TypeKind.DOUBLE },
+        types = { String.class, Double.class, Boolean.class, Byte.class,
+                Character.class, Float.class, Integer.class, Long.class,
+                Short.class }
         )
+@QualifierForLiterals({ LiteralKind.ALL })
 public @interface Bottom {}


### PR DESCRIPTION
I made some changes so that universe can pass `gradle build` compilation.
These changes allow the `:compileJava` step to pass, but `:test` still fails.

My changes were:
1. `ImplicitFor` --> `DefaultFor` or `QualifierForLiterals`
2. Remove `checkConflictingPrimaryAnnos(type, p);` in `GUTValidator`. I'm not sure if it ever was used.
3. Update some incompatible function calls to CF/CFI