### PR TITLE
Remove unnecessary return statement in visitor

### DIFF
--- a/src/main/java/universe/UniverseVisitor.java
+++ b/src/main/java/universe/UniverseVisitor.java
@@ -63,7 +63,6 @@ public class UniverseVisitor extends BaseTypeVisitor<UniverseAnnotatedTypeFactor
     @Override
     protected void checkMethodInvocability(
             AnnotatedExecutableType method, MethodInvocationTree node) {
-        return;
     }
 
     /** Ignore constructor receiver annotations. */

--- a/src/main/java/universe/UniverseVisitor.java
+++ b/src/main/java/universe/UniverseVisitor.java
@@ -62,8 +62,7 @@ public class UniverseVisitor extends BaseTypeVisitor<UniverseAnnotatedTypeFactor
     /** Ignore method receiver annotations. */
     @Override
     protected void checkMethodInvocability(
-            AnnotatedExecutableType method, MethodInvocationTree node) {
-    }
+            AnnotatedExecutableType method, MethodInvocationTree node) {}
 
     /** Ignore constructor receiver annotations. */
     @Override


### PR DESCRIPTION
This PR fixes the following warning while build universe checker.

UniverseVisitor.java:64: warning: [ReturnAtTheEndOfVoidFunction] `return;` is unnecessary at the end of void methods and constructors.
    protected void checkMethodInvocability(
                   ^
    (see https://errorprone.info/bugpattern/ReturnAtTheEndOfVoidFunction)
  Did you mean to remove this line?
1 warning
