### PR TITLE
Updated Readme with Linter Options for Encapsulation Checks (OaM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ cd universe
 ./.ci-build.sh
 ````
 
+## Supported Options
+
+Linter options:
+* `checkOaM` Enables encapsulation checks (Owner-as-Modifier). Without this option, only topology checks are performed,
+  so make sure to enable set this option if it should be checked that `@Any` references are not used for writing.
+
+Linter options can be passed via `-Alint=<option>`. Note that everything except the last option given in that way is
+ignored (see https://checkerframework.org/manual/#alint for more details)!
 
 ## Type checking example
 

--- a/src/main/java/universe/jdk.astub
+++ b/src/main/java/universe/jdk.astub
@@ -3,10 +3,10 @@ import universe.qual.Any;
 package java.io;
 
 class PrintStream {
-  public void print(@Any char[] s);
+  public void print(char @Any [] s);
   public void print(@Any String s);
   public void print(@Any Object obj);
-  public void println(@Any char[] x);
+  public void println(char @Any [] x);
   public void println(@Any String s);
   public void println(@Any Object x);
 }

--- a/src/main/java/universe/jdk.astub
+++ b/src/main/java/universe/jdk.astub
@@ -1,5 +1,16 @@
 import universe.qual.Any;
 
+package java.io;
+
+class PrintStream {
+  public void print(@Any char[] s);
+  public void print(@Any String s);
+  public void print(@Any Object obj);
+  public void println(@Any char[] x);
+  public void println(@Any String s);
+  public void println(@Any Object x);
+}
+
 package java.lang;
 
 class Object {


### PR DESCRIPTION
In this small PR, I added a section in the Readme about the OaM (Owner as Modifier) linter option, since it was not documented so far.

I noticed that in the code there are more supported options. However, two of them (`warn`, `allowLost`) are declared in the code but seem to be unused, and the third one (`checkStrictPurity`) just checks that the code does not contain any assignments at all. So I don't think it is very useful to document these, but if desired I can add it ...

This PR should be merged after #120.
