### PR TITLE
Fix for assignment check with type vars and OaM 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ cd universe
 ./.ci-build.sh
 ````
 
+## Supported Options
+
+Linter options:
+* `checkOaM` Enables encapsulation checks (Owner-as-Modifier). Without this option, only topology checks are performed,
+  so make sure to enable set this option if it should be checked that `@Any` references are not used for writing.
+
+Linter options can be passed via `-Alint=<option>`. Note that everything except the last option given in that way is
+ignored (see https://checkerframework.org/manual/#alint for more details)!
 
 ## Type checking example
 

--- a/src/main/java/universe/UniverseVisitor.java
+++ b/src/main/java/universe/UniverseVisitor.java
@@ -235,10 +235,9 @@ public class UniverseVisitor extends BaseTypeVisitor<UniverseAnnotatedTypeFactor
                 AnnotatedTypeMirror receiverType = atypeFactory.getAnnotatedType(receiverTree);
 
                 if (receiverType != null) {
-                    // Still, I think receiver can still only be declared types, so
-                    // effectiveAnnotation
-                    // is not needed.
-                    if (receiverType.hasAnnotation(LOST) || receiverType.hasAnnotation(ANY)) {
+                    // We need to check effective annotations, since receiver type could be a type
+                    // variable of the class.
+                    if (receiverType.hasEffectiveAnnotation(LOST) || receiverType.hasEffectiveAnnotation(ANY)) {
                         checker.reportError(node, "oam.assignment.forbidden");
                     }
                 }

--- a/src/main/java/universe/jdk.astub
+++ b/src/main/java/universe/jdk.astub
@@ -3,10 +3,10 @@ import universe.qual.Any;
 package java.io;
 
 class PrintStream {
-  public void print(@Any char[] s);
+  public void print(char @Any [] s);
   public void print(@Any String s);
   public void print(@Any Object obj);
-  public void println(@Any char[] x);
+  public void println(char @Any [] x);
   public void println(@Any String s);
   public void println(@Any Object x);
 }

--- a/src/main/java/universe/jdk.astub
+++ b/src/main/java/universe/jdk.astub
@@ -1,5 +1,16 @@
 import universe.qual.Any;
 
+package java.io;
+
+class PrintStream {
+  public void print(@Any char[] s);
+  public void print(@Any String s);
+  public void print(@Any Object obj);
+  public void println(@Any char[] x);
+  public void println(@Any String s);
+  public void println(@Any Object x);
+}
+
 package java.lang;
 
 class Object {


### PR DESCRIPTION
This PR fixes a bug in the assignment check, where fields of an `@Any` object could be assigned even though `-Alint=checkOaM` was activated. The cause was a missing use of effective annotations.

Minimal example where the bug occurs (I can add a test case if desired):
```java
class IntCell {
  int f;
}

class L<T extends @Any IntCell> {
  void m(T x) {
    x.f = 5;  // should not be allowed with OaM, but the checker does not complain
  }
}
```

Note:
* This builds on my other PRs, #120 and #123, which should be merged first.
* I am not sure if there is a corresponding case in the inference checker ...
